### PR TITLE
Switch to httpx and async route

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-flask
-requests
+flask>=2.0
+httpx
 scikit-learn
 waitress
 numpy


### PR DESCRIPTION
## Summary
- use `httpx` and drop `requests`
- support async fetching in `app.py`
- update package requirements to Flask 2 and use httpx

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458095c8dc8330acc55b45bec51e7e