### PR TITLE
Fix missing images on about page

### DIFF
--- a/templates/aboutus.html
+++ b/templates/aboutus.html
@@ -27,12 +27,12 @@
             <h3>Meet Our Team</h3>
             <div class="team-members">
                 <article class="team-member">
-                    <img src="static/images/team-member-1.jpg" alt="John Doe">
+                    <img src="https://via.placeholder.com/150" alt="John Doe">
                     <h4>John Doe</h4>
                     <p>Founder & CEO</p>
                 </article>
                 <article class="team-member">
-                    <img src="static/images/team-member-2.jpg" alt="Jane Doe">
+                    <img src="https://via.placeholder.com/150" alt="Jane Doe">
                     <h4>Jane Doe</h4>
                     <p>Chief Technology Officer</p>
                 </article>


### PR DESCRIPTION
## Summary
- replace missing references in `aboutus.html` with remote placeholder images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845808bff908330a174bb3ad3c90d12