### PR TITLE
Fix API token usage bug in app

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,10 +8,12 @@ app = Flask(__name__)
 
 # Securely set the API token using environment variables
 ipinfo_api_token = os.getenv("IPINFO_API_TOKEN", "your_ipinfo_api_token")
-threat_intelligence_api_token = os.getenv("THREAT_INTELLIGENCE_API_TOKEN", "your_threat_intelligence_api_token")
+threat_intel_api_token = os.getenv(
+    "THREAT_INTELLIGENCE_API_TOKEN", "your_threat_intelligence_api_token"
+)
 
 # Define the function for threat intelligence check outside of the route
-def threat_intelligence_api_token(ip_address, api_token):
+def fetch_threat_intelligence(ip_address: str, api_token: str):
     # Make sure to use the actual threat intelligence API endpoint
     url = f"https://api.abuseipdb.com/ip/{ip_address}"
     headers = {'Authorization': f'Bearer {api_token}'}
@@ -34,7 +36,9 @@ def result():
         ip_address = request.form["ip_address"]
         
         # Retrieve the IP address information from ipinfo
-        response = requests.get(f"https://ipinfo.io/{ip_address}?token=your_ipinfo_api_token")
+        response = requests.get(
+            f"https://ipinfo.io/{ip_address}?token={ipinfo_api_token}"
+        )
         if response.status_code == 200:
             data = response.json()
             region = data.get("region", "Not Available")
@@ -42,7 +46,7 @@ def result():
             country = data.get("country", "Not Available")
             
             # Check IP against threat intelligence API
-            threat_info = threat_intelligence_api_token(ip_address, "your_threat_intelligence_api_token")
+            threat_info = fetch_threat_intelligence(ip_address, threat_intel_api_token)
             
             # Assuming the threat info contains a key "is_malicious" for simplicity
             is_malicious = threat_info.get("is_malicious") if threat_info else False


### PR DESCRIPTION
## Summary
- use environment variables for API tokens
- avoid name conflict by renaming threat intelligence helper

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68457d4ca4f483309c1ee3c3d4a4bb07