### PR TITLE
Fix Netlify 404 messaging

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app

--- a/README.md
+++ b/README.md
@@ -65,6 +65,36 @@ These instructions will get you a copy of the project up and running on your loc
    python3 app.py
    ```
 
+## Deployment
+
+Netlify only serves static files and does not run the Flask server that powers
+this project. Deploying the repository directly to Netlify will therefore result
+in a 404 page. Use a platform that supports Python web services, such as
+[Render](https://render.com) or Heroku. A simple `index.html` is included so
+that anyone visiting a Netlify deployment sees a helpful message instead of a
+generic 404 page.
+
+### Deploying to Render
+
+1. Create an account at [Render](https://render.com) and click **New > Web Service**.
+2. Connect your GitHub repository and select the branch to deploy.
+3. For the build command enter:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Set the start command to:
+
+   ```bash
+   gunicorn app:app
+   ```
+
+5. Add the environment variables `IPINFO_API_TOKEN` and
+   `THREAT_INTELLIGENCE_API_TOKEN` in the service settings.
+6. Click **Create Web Service** to trigger the initial deployment. Render will
+   build the container and provide a public URL where the Flask application runs.
+
 ## How to Use
 
 1. **Enter the IP Address**: Simply type the IP address you wish to analyze into the input field.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SafeStreet IP Analyzer</title>
+</head>
+<body>
+    <h1>SafeStreet IP Analyzer</h1>
+    <p>This application requires a Python server and cannot run on Netlify's static hosting.</p>
+    <p>Please deploy it on a platform that supports Flask, such as Render or Heroku. See the README for instructions.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- note in README that Netlify only serves static files
- add a simple `index.html` so a Netlify deploy shows a message instead of 404

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845855818c08330920a3ae63bc4cf33